### PR TITLE
Add agentic search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ RAG on Markdown Files
 - Setup Config JSON
 - Run `run-index config.json`
 - Run `run-server config.json` and open `http://localhost:4567/q.html`
+- Use **Search** for standard retrieval or **Search+** to try the agentic query expansion.

--- a/public/q.html
+++ b/public/q.html
@@ -48,6 +48,12 @@
             font-size: 16px;
             margin-left: 10px;
         }
+        #search-plus-button {
+            width: 100px;
+            height: 66px;
+            font-size: 16px;
+            margin-left: 10px;
+        }
         #response-container {
             display: flex;
             flex-wrap: wrap;
@@ -68,6 +74,7 @@
         <div id="search-container">
             <input type="text" id="search-input" placeholder="Enter your search query">
             <button id="search-button">Search</button>
+            <button id="search-plus-button">Search+</button>
         </div>
         <div id="paths-container">
             <label><input type="checkbox" id="config-experiment-checkbox"> Experiment</label>
@@ -81,6 +88,7 @@
             const pathsList = document.getElementById('paths-list');
             const searchInput = document.getElementById('search-input');
             const searchButton = document.getElementById('search-button');
+            const searchPlusButton = document.getElementById('search-plus-button');
             const configExperimentCheckbox = document.getElementById('config-experiment-checkbox');
             const responseContainer = document.getElementById('response-container');
 
@@ -156,6 +164,60 @@
                 .catch(error => console.error('Error performing search:', error));
             }
 
+            function performAgentSearch() {
+                const query = searchInput.value;
+                const configExperiment = configExperimentCheckbox.checked
+                const checkedPaths = Array.from(pathsList.querySelectorAll('input[type="checkbox"]:checked'))
+                    .map(checkbox => checkbox.name);
+
+                fetch('http://localhost:4567/q_plus', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        q: query,
+                        paths: checkedPaths,
+                        experiment: configExperiment,
+                    })
+                })
+                .then(response => response.json())
+                .then(resp => {
+                    responseContainer.innerHTML = '';
+
+                    if (!!resp.expanded) {
+                        const div = document.createElement('div');
+                        div.className = 'response-item';
+                        div.style.backgroundColor = textToLightColor("expanded");
+                        div.innerHTML = `<div><strong>Expanded Query:</strong> ${resp.expanded}</div>`;
+                        responseContainer.appendChild(div);
+                    }
+
+                    if (!!resp.eval) {
+                        const div = document.createElement('div');
+                        div.className = 'response-item';
+                        div.style.backgroundColor = textToLightColor("experiment");
+                        div.innerHTML = `
+                            <div class="markdown-content">${marked.parse(resp.eval)}</div>
+                        `;
+                        responseContainer.appendChild(div);
+                    }
+
+                    resp.data.forEach(item => {
+                        const div = document.createElement('div');
+                        div.className = 'response-item';
+                        div.style.backgroundColor = textToLightColor(item.lookup);
+                        div.innerHTML = `
+                            <div><strong>Path:</strong> <a href="${item.url}">${item.id}</a></div>
+                            <div><strong>Score:</strong> ${item.score}</div>
+                            <div class="markdown-content">${marked.parse(item.text)}</div>
+                        `;
+                        responseContainer.appendChild(div);
+                    });
+                })
+                .catch(error => console.error('Error performing agent search:', error));
+            }
+
             function textToLightColor(text) {
                 // Generate a hash from the text
                 let hash = 0;
@@ -174,6 +236,7 @@
 
             // Event listeners
             searchButton.addEventListener('click', performSearch);
+            searchPlusButton.addEventListener('click', performAgentSearch);
             searchInput.addEventListener('keypress', function(e) {
                 if (e.key === 'Enter') {
                     performSearch();

--- a/run-server
+++ b/run-server
@@ -79,3 +79,43 @@ post '/q' do
 
     resp.to_json
 end
+
+# agentic query - expand the query using LLM before searching
+post '/q_plus' do
+    content_type :json
+
+    data = JSON.parse(request.body.read)
+
+    lookup_paths = (data["paths"] || CONFIG.paths_map.keys).map do |name|
+        CONFIG.path_map[name]
+    end
+
+    topN = (data["topN"] || 20).to_i
+
+    expanded_q = expand_query(data["q"])
+    entries = retrieve_by_embedding(lookup_paths, expanded_q)
+    entries = entries.sort_by { |item| -item["score"] }.take(topN)
+
+    resp = {
+        data: [],
+        expanded: expanded_q,
+        eval: nil,
+    }
+
+    entries.each do |item|
+        resp[:data] << {
+            path: item["path"],
+            lookup: item["lookup"],
+            id: item["id"],
+            url: item["url"],
+            text: item["reader"].load.get_chunk(item["chunk"]),
+            score: item["score"],
+        }
+    end
+
+    if data["experiment"]
+        resp[:eval] = update_memory(expanded_q, resp[:data])
+    end
+
+    resp.to_json
+end

--- a/server/retriever.rb
+++ b/server/retriever.rb
@@ -7,6 +7,19 @@ require_relative "../llm/embedding"
 
 require_relative "../readers/reader"
 
+AGENT_PROMPT = <<~PROMPT
+You expand a short search query so it is easier to retrieve related markdown
+documents. Return only the expanded query in a single line.
+PROMPT
+
+def expand_query(q)
+    msgs = [
+        { role: ROLE_SYSTEM, content: AGENT_PROMPT },
+        { role: ROLE_USER, content: q },
+    ]
+    chat(msgs).strip
+end
+
 def retrieve_by_embedding(lookup_paths, q)
     qe = CACHE.get_or_set(q, method(:embedding).to_proc)
 


### PR DESCRIPTION
## Summary
- expose an agentic query expansion endpoint in the server
- add `expand_query` helper for OpenAI
- update the HTML frontend with a **Search+** button and handler
- document the new functionality in README

## Testing
- `ruby -c run-server`
- `ruby -c server/retriever.rb`


------
https://chatgpt.com/codex/tasks/task_e_683fecadf9f0832698741b759001b6f2