### PR TITLE
Add discuss feature

### DIFF
--- a/public/q.html
+++ b/public/q.html
@@ -72,6 +72,9 @@
             width: calc(50% - 5px);
             box-sizing: border-box;
         }
+        .discuss-button {
+            margin-top: 10px;
+        }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
@@ -149,11 +152,17 @@
                         const div = document.createElement('div');
                         div.className = 'response-item';
                         div.style.backgroundColor = textToLightColor(item.lookup);
+                        div.dataset.note = item.text;
                         div.innerHTML = `
                             <div><strong>Path:</strong> <a href="${item.url}">${item.id}</a></div>
                             <div><strong>Score:</strong> ${item.score}</div>
                             <div class="markdown-content">${marked.parse(item.text)}</div>
                         `;
+                        const btn = document.createElement('button');
+                        btn.className = 'discuss-button';
+                        btn.textContent = 'Discuss';
+                        btn.addEventListener('click', () => discussCard(div));
+                        div.appendChild(btn);
                         responseContainer.appendChild(div);
                         retrievedNotes.push(item.text);
                     });
@@ -193,11 +202,17 @@
                         const div = document.createElement('div');
                         div.className = 'response-item';
                         div.style.backgroundColor = textToLightColor(item.lookup);
+                        div.dataset.note = item.text;
                         div.innerHTML = `
                             <div><strong>Path:</strong> <a href="${item.url}">${item.id}</a></div>
                             <div><strong>Score:</strong> ${item.score}</div>
                             <div class="markdown-content">${marked.parse(item.text)}</div>
                         `;
+                        const btn = document.createElement('button');
+                        btn.className = 'discuss-button';
+                        btn.textContent = 'Discuss';
+                        btn.addEventListener('click', () => discussCard(div));
+                        div.appendChild(btn);
                         responseContainer.appendChild(div);
                         retrievedNotes.push(item.text);
                     });
@@ -248,11 +263,17 @@
                         const div = document.createElement('div');
                         div.className = 'response-item';
                         div.style.backgroundColor = textToLightColor(item.lookup);
+                        div.dataset.note = item.text;
                         div.innerHTML = `
                             <div><strong>Path:</strong> <a href="${item.url}">${item.id}</a></div>
                             <div><strong>Score:</strong> ${item.score}</div>
                             <div class="markdown-content">${marked.parse(item.text)}</div>
                         `;
+                        const btn = document.createElement('button');
+                        btn.className = 'discuss-button';
+                        btn.textContent = 'Discuss';
+                        btn.addEventListener('click', () => discussCard(div));
+                        div.appendChild(btn);
                         responseContainer.appendChild(div);
                     });
                 })
@@ -300,6 +321,29 @@
                     responseContainer.prepend(div);
                 })
                 .catch(error => console.error('Error synthesizing notes:', error));
+            }
+
+            function discussCard(div) {
+                const note = div.dataset.note;
+                if (!note) {
+                    return;
+                }
+
+                fetch('http://localhost:4567/discuss', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        note: note,
+                    })
+                })
+                .then(response => response.json())
+                .then(resp => {
+                    const mdDiv = div.querySelector('.markdown-content');
+                    mdDiv.innerHTML += marked.parse(resp.discussion);
+                })
+                .catch(error => console.error('Error discussing note:', error));
             }
 
             // Event listeners

--- a/run-server
+++ b/run-server
@@ -13,6 +13,7 @@ require "sinatra"
 
 require_relative "server/retriever"
 require_relative "server/synthesizer"
+require_relative "server/discuss"
 
 if ARGV.length != 1
     STDOUT << "Invalid arguments received, need a config file\n"
@@ -119,4 +120,15 @@ post '/synthesize' do
     summary = synthesize_notes(data["notes"])
 
     { note: summary }.to_json
+end
+
+# generate discussion for a single note
+post '/discuss' do
+    content_type :json
+
+    data = JSON.parse(request.body.read)
+
+    discussion = discuss_note(data["note"])
+
+    { discussion: discussion }.to_json
 end

--- a/server/discuss.rb
+++ b/server/discuss.rb
@@ -1,0 +1,19 @@
+DISCUSS_PROMPT = <<~PROMPT
+You provide a short discussion of a note from multiple perspectives.
+Focus on explaining key concepts succinctly.
+PROMPT
+
+require_relative "../llm/openai"
+
+# note: string
+# Returns discussion text
+def discuss_note(note)
+    return "" if note.nil? || note.strip.empty?
+
+    msgs = [
+        { role: ROLE_SYSTEM, content: DISCUSS_PROMPT },
+        { role: ROLE_USER, content: note },
+    ]
+
+    chat(msgs)
+end


### PR DESCRIPTION
## Summary
- add discussion generator endpoint and helper
- expose `/discuss` in server
- include Discuss button on search result cards

## Testing
- `ruby -c run-server`
- `ruby -c server/discuss.rb`


------
https://chatgpt.com/codex/tasks/task_e_684073306ec4832690ba6c64e8055dc1