### PR TITLE
Add fast text match retrieval in search+

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 RAG on Markdown Files
 
 - Use **Search** for standard retrieval
-- Use **Search+** for agentic query expansion
+- Use **Search+** for agentic query expansion and fast text match
 - Use **Synthesize** to combine retrieved notes
 
 ## Setup

--- a/run-server
+++ b/run-server
@@ -89,15 +89,32 @@ post '/q_plus' do
     topN = (data["topN"] || 20).to_i
 
     expanded_q = expand_query(data["q"])
-    entries = retrieve_by_embedding(lookup_paths, expanded_q)
-    entries = entries.sort_by { |item| -item["score"] }.take(topN)
+    variants = expand_variants(data["q"])
+
+    entries = []
+    entries.concat(retrieve_by_embedding(lookup_paths, data["q"]))
+    entries.concat(retrieve_by_embedding(lookup_paths, expanded_q))
+    variants.each { |v| entries.concat(retrieve_by_text(lookup_paths, v)) }
+
+    unique = {}
+    entries.each do |e|
+        key = [e["path"], e["chunk"]]
+        if unique[key]
+            unique[key]["score"] = [unique[key]["score"], e["score"]].max
+        else
+            unique[key] = e
+        end
+    end
+
+    ordered = unique.values.sort_by { |item| -item["score"] }.take(topN)
 
     resp = {
         data: [],
         expanded: expanded_q,
+        variants: variants,
     }
 
-    entries.each do |item|
+    ordered.each do |item|
         resp[:data] << {
             path: item["path"],
             lookup: item["lookup"],


### PR DESCRIPTION
## Summary
- support fast text match for query variants
- merge embedding and text results in search+
- mention fast text match in README

## Testing
- `ruby -c run-server`
- `ruby -c server/retriever.rb`


------
https://chatgpt.com/codex/tasks/task_e_6843b8e66a8483268ea2bdaad5a7fcc4