### PR TITLE
Fix repeated load calls causing nil returns

### DIFF
--- a/readers/note.rb
+++ b/readers/note.rb
@@ -15,7 +15,7 @@ class NoteReader
     end
 
     def load
-        return if @loaded
+        return self if @loaded
 
         File.open(@file) do |file|
             parse_conf(file)

--- a/readers/text.rb
+++ b/readers/text.rb
@@ -9,7 +9,7 @@ class TextReader
     end
 
     def load
-        return if @loaded
+        return self if @loaded
 
         chunk = ""
         File.foreach(@file) do |line|


### PR DESCRIPTION
## Summary
- fix `NoteReader#load` and `TextReader#load` to always return `self`

## Testing
- `ruby -c readers/text.rb`
- `ruby -c readers/note.rb`
- `ruby -c run-server`


------
https://chatgpt.com/codex/tasks/task_e_6843be07a1548326b380cb18d12eb437