### PR TITLE
Fix run-server entrypoint after gem install

### DIFF
--- a/exe/run-server
+++ b/exe/run-server
@@ -165,3 +165,5 @@ post '/discuss' do
 
     { discussion: discussion }.to_json
 end
+
+run! if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
## Summary
- ensure Sinatra server starts when using the gem's wrapper script

## Testing
- `ruby -e 'require "sinatra"; p Sinatra::VERSION'` *(fails: missing rackup gem)*

------
https://chatgpt.com/codex/tasks/task_e_6843f459929483269458cdf31e52bb9f