### PR TITLE
Fix config usage for provider and model

### DIFF
--- a/exe/run-index
+++ b/exe/run-index
@@ -11,8 +11,7 @@ require "json"
 require "ostruct"
 require "digest"
 
-require_relative "../llm/openai"
-require_relative "../llm/embedding"
+require_relative "../llm/llm"
 require_relative "../readers/reader"
 
 if ARGV.length != 1

--- a/lib/simple_rag.rb
+++ b/lib/simple_rag.rb
@@ -8,8 +8,7 @@ $LOAD_PATH.unshift File.expand_path("..", __dir__)
 module SimpleRag
 end
 
-require "llm/openai"
-require "llm/embedding"
+require "llm/llm"
 require "readers/reader"
 require "server/retriever"
 require "server/synthesizer"

--- a/llm/ollama.rb
+++ b/llm/ollama.rb
@@ -1,13 +1,12 @@
 require_relative "http"
 
-def embedding_ollama(txts, opts = {})
+def ollama_embedding(txts, model, url, opts = {})
   data = {
-    "model" => "nomic-embed-text",
+    "model" => model,
     "prompt" => txts
   }.merge(opts)
 
-  uri = "http://localhost:11434/api/embeddings"
-  response = http_post(uri, nil, data)
+  response = http_post(url, nil, data)
 
   if response.code != "200"
     STDOUT << "Embedding error: #{response}\n"
@@ -16,4 +15,25 @@ def embedding_ollama(txts, opts = {})
 
   result = JSON.parse(response.body)
   result["embedding"]
+end
+
+def ollama_chat(messages, model, url, opts = {})
+  data = {
+    "model" => model,
+    "messages" => messages
+  }.merge(opts)
+
+  response = http_post(url, nil, data)
+
+  if response.code != "200"
+    STDOUT << "Chat error: #{response}\n"
+    exit 1
+  end
+
+  result = JSON.parse(response.body)
+  if result.is_a?(Hash) && result["message"]
+    result["message"]["content"]
+  else
+    result["choices"][0]["message"]["content"]
+  end
 end

--- a/llm/openai.rb
+++ b/llm/openai.rb
@@ -1,18 +1,12 @@
 require_relative "http"
 
-ROLE_SYSTEM = "system"
-ROLE_USER = "user"
-ROLE_ASSISTANT = "assistant"
-NEXT_ROLE = ->(role) { role != ROLE_USER ? ROLE_USER : ROLE_ASSISTANT }
-
-def chat(messages, opts = {})
+def openai_chat(messages, model, url, opts = {})
   data = {
-    "model" => "gpt-4.1-mini",
+    "model" => model,
     "messages" => messages
   }.merge(opts)
 
-  uri = "https://api.openai.com/v1/chat/completions"
-  response = http_post(uri, OPENAI_KEY, data)
+  response = http_post(url, OPENAI_KEY, data)
 
   if response.code != "200"
     STDOUT << "Chat error: #{response}\n"
@@ -25,14 +19,13 @@ def chat(messages, opts = {})
   result["choices"][0]["message"]["content"]
 end
 
-def embedding(txts, opts = {})
+def openai_embedding(txts, model, url, opts = {})
   data = {
-    "model" => "text-embedding-3-small",
+    "model" => model,
     "input" => txts
   }.merge(opts)
 
-  uri = "https://api.openai.com/v1/embeddings"
-  response = http_post(uri, OPENAI_KEY, data)
+  response = http_post(url, OPENAI_KEY, data)
 
   if response.code != "200"
     STDOUT << "Embedding error: #{response.body}\n"

--- a/server/discuss.rb
+++ b/server/discuss.rb
@@ -3,7 +3,7 @@ You provide a short discussion of a note from multiple perspectives.
 Focus on explaining key concepts succinctly.
 PROMPT
 
-require_relative "../llm/openai"
+require_relative "../llm/llm"
 
 # note: string
 # Returns discussion text

--- a/server/retriever.rb
+++ b/server/retriever.rb
@@ -2,8 +2,7 @@ require "pathname"
 
 require_relative "cache"
 
-require_relative "../llm/openai"
-require_relative "../llm/embedding"
+require_relative "../llm/llm"
 
 require_relative "../readers/reader"
 

--- a/server/synthesizer.rb
+++ b/server/synthesizer.rb
@@ -2,7 +2,7 @@ SUM_PROMPT = """You are an expert at combining notes.
 Given a collection of notes, synthesize them into a concise new note capturing the key points.
 """
 
-require_relative "../llm/openai"
+require_relative "../llm/llm"
 
 # notes: array of strings
 # Returns summary text


### PR DESCRIPTION
## Summary
- ensure chat and embedding functions honor provider/model fields from config
- support ollama embeddings if configured
- add new LLM routing module and provider-specific helpers

## Testing
- `ruby -c llm/openai.rb`
- `ruby -c llm/ollama.rb`
- `ruby -c llm/llm.rb`
- `ruby -c exe/run-index`
- `ruby -c exe/run-server`
- `ruby -c server/retriever.rb`
- `ruby -c server/discuss.rb`
- `ruby -c server/synthesizer.rb`
- `ruby -c lib/simple_rag.rb`

------
https://chatgpt.com/codex/tasks/task_e_684402cd62308326aa336db8c17ef44a