### PR TITLE
Add searchDefault config for paths

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -17,7 +17,8 @@
             "dir": "D:\\Studies\\tmp\\learning",
             "out": "D:\\Studies\\tmp\\learning\\learning.dt",
             "nameMatch": "talks-*.md",
-            "url": ""
+            "url": "",
+            "searchDefault": false
         }
     ]
 }

--- a/exe/public/q.html
+++ b/exe/public/q.html
@@ -114,7 +114,7 @@
                         checkbox.type = 'checkbox';
                         checkbox.id = item.name;
                         checkbox.name = item.name;
-                        checkbox.checked = true;
+                        checkbox.checked = !!item.searchDefault;
 
                         const label = document.createElement('label');
                         label.htmlFor = item.name;

--- a/exe/public/setup.html
+++ b/exe/public/setup.html
@@ -49,6 +49,7 @@
             <label>Out: <input type="text" class="pout" value="${p?.out||''}"></label>
             <label>NameMatch: <input type="text" class="pnamematch" value="${p?.nameMatch||''}"></label>
             <label>URL: <input type="text" class="purl" value="${p?.url||''}"></label>
+            <label>Search Default: <input type="checkbox" class="psearchdefault" ${p?.searchDefault?'checked':''}></label>
             <button type="button" onclick="this.parentNode.remove()">Remove</button>
         `;
         const dirInput = div.querySelector('#dir_'+idx);
@@ -114,7 +115,8 @@
                 threshold: parseFloat(div.querySelector('.pthreshold').value)||0,
                 out: div.querySelector('.pout').value,
                 nameMatch: div.querySelector('.pnamematch').value,
-                url: div.querySelector('.purl').value
+                url: div.querySelector('.purl').value,
+                searchDefault: div.querySelector('.psearchdefault').checked
             });
         });
         const config={

--- a/exe/run-server
+++ b/exe/run-server
@@ -23,6 +23,7 @@ end
 config = JSON.parse(File.read(ARGV[0]))
 CONFIG = OpenStruct.new(config)
 CONFIG.paths = CONFIG.paths.map { |p| OpenStruct.new(p) }
+CONFIG.paths.each { |p| p.searchDefault = !!p.searchDefault }
 CONFIG.path_map = {}
 CONFIG.paths.each { |p| CONFIG.path_map[p.name] = p }
 
@@ -39,7 +40,7 @@ class SimpleRagServer < Sinatra::Application
 
         resp = []
         CONFIG.paths.each do |p|
-            resp << { "name": p.name }
+            resp << { name: p.name, searchDefault: p.searchDefault }
         end
         resp.to_json
     end
@@ -50,9 +51,12 @@ class SimpleRagServer < Sinatra::Application
 
         data = JSON.parse(request.body.read)
 
-        lookup_paths = (data["paths"] || CONFIG.paths_map.keys).map do |name|
-            CONFIG.path_map[name]
+        selected = data["paths"]
+        if !selected || selected.empty?
+            selected = CONFIG.paths.select { |p| p.searchDefault }.map(&:name)
+            selected = CONFIG.path_map.keys if selected.empty?
         end
+        lookup_paths = selected.map { |name| CONFIG.path_map[name] }
 
         topN = (data["topN"] || 20).to_i
 
@@ -99,9 +103,12 @@ class SimpleRagServer < Sinatra::Application
 
         data = JSON.parse(request.body.read)
 
-        lookup_paths = (data["paths"] || CONFIG.paths_map.keys).map do |name|
-            CONFIG.path_map[name]
+        selected = data["paths"]
+        if !selected || selected.empty?
+            selected = CONFIG.paths.select { |p| p.searchDefault }.map(&:name)
+            selected = CONFIG.path_map.keys if selected.empty?
         end
+        lookup_paths = selected.map { |name| CONFIG.path_map[name] }
 
         topN = (data["topN"] || 20).to_i
 


### PR DESCRIPTION
## Summary
- add `searchDefault` to example config
- support `searchDefault` in run-server path handling
- expose `searchDefault` through `/paths`
- respect `searchDefault` when no paths are provided for search
- update UI to persist/display search default choice

## Testing
- `ruby -c exe/run-server`
- `ruby -c exe/run-setup`
- `ruby -c exe/run-index`


------
https://chatgpt.com/codex/tasks/task_e_684412fb544c8326974316d6735a0b84