### PR TITLE
Ignore YAML frontmatter in TextReader

### DIFF
--- a/readers/text.rb
+++ b/readers/text.rb
@@ -12,13 +12,26 @@ class TextReader
         return self if @loaded
 
         chunk = ""
+        in_frontmatter = false
         File.foreach(@file) do |line|
-            if line.start_with?(/- .+:/) || line.start_with?('  - [[') # yaml like
+            stripped = line.strip
+
+            if in_frontmatter
+                if stripped == '---' || stripped == '...'
+                    in_frontmatter = false
+                end
                 next
-            elsif line.start_with?('<') # html like
+            elsif stripped == '---'
+                in_frontmatter = true
+                next
+            end
+
+            if line.start_with?('- ') && line.include?(':') || line.start_with?('  - [[')
+                next
+            elsif line.start_with?('<')
                 next
             else
-                chunk << line unless line.strip.empty?
+                chunk << line unless stripped.empty?
             end
         end
 


### PR DESCRIPTION
## Summary
- update `TextReader` to skip YAML front matter blocks

## Testing
- `ruby -c readers/text.rb`
- `ruby readers/check-reader.rb text README.md | head`

------
https://chatgpt.com/codex/tasks/task_e_68441899ca9083268b44ef478ed46774