### PR TITLE
Improve indexing robustness and chunk splitting

### DIFF
--- a/exe/run-index
+++ b/exe/run-index
@@ -62,23 +62,28 @@ CONFIG.paths.each do |path|
     created = 0
     File.open(index_file, "w") do |index_newdb|
         files.each_with_index do |file, file_idx|
-            chunks = reader_class.new(file).load.chunks
+            begin
+                chunks = reader_class.new(file).load.chunks
 
-            chunks.each_with_index do |chunk, chunk_idx|
-                hash = Digest::SHA256.hexdigest(chunk)
+                chunks.each_with_index do |chunk, chunk_idx|
+                    hash = Digest::SHA256.hexdigest(chunk)
 
-                if index_db[hash] # found in old DB
-                    index_newdb.puts(index_db[hash].to_json)
+                    if index_db[hash] # found in old DB
+                        index_newdb.puts(index_db[hash].to_json)
 
-                    skipped += 1
-                    next
+                        skipped += 1
+                        next
+                    end
+
+                    created += 1
+                    embedding = embedding(chunk)
+
+                    line = { path: file, hash: hash, chunk: chunk_idx, embedding: embedding }
+                    index_newdb.puts(line.to_json)
                 end
-
-                created += 1
-                embedding = embedding(chunk)
-
-                line = { path: file, hash: hash, chunk: chunk_idx, embedding: embedding }
-                index_newdb.puts(line.to_json)
+            rescue => e
+                STDOUT << "\nError indexing #{file}: #{e}\n"
+                next
             end
 
             if file_idx % 50 == 0 # flush the file writes

--- a/readers/text.rb
+++ b/readers/text.rb
@@ -64,11 +64,8 @@ class TextReader
 
     def count_tokens(str)
         return 0 if str.nil? || str.empty?
-        if str.match?(/\s/)
-            str.split(/\s+/).length
-        else
-            str.length
-        end
+        tokens = str.scan(/[\p{Han}]|[\p{L}\p{N}]+|[^\s]/)
+        tokens.length
     end
 
     def get_chunk(idx)

--- a/readers/text.rb
+++ b/readers/text.rb
@@ -8,11 +8,16 @@ class TextReader
         @chunks = []
     end
 
+    MAX_WORDS = 7900
+
     def load
         return self if @loaded
 
-        chunk = ""
+        lines = []
+        boundary = 0
+        words = 0
         in_frontmatter = false
+
         File.foreach(@file) do |line|
             stripped = line.strip
 
@@ -26,19 +31,44 @@ class TextReader
                 next
             end
 
-            if line.start_with?('- ') && line.include?(':') || line.start_with?('  - [[')
+            if (line.start_with?('- ') && line.include?(':')) || line.start_with?('  - [[')
                 next
             elsif line.start_with?('<')
                 next
-            else
-                chunk << line unless stripped.empty?
+            end
+
+            if stripped == '---'
+                boundary = lines.length
+                next
+            end
+
+            lines << line
+            words += count_tokens(stripped)
+
+            boundary = lines.length if stripped.empty?
+
+            if words >= MAX_WORDS
+                split_at = boundary.zero? ? lines.length : boundary
+                @chunks << lines[0, split_at].join
+                lines = lines[split_at..-1] || []
+                words = lines.sum { |l| count_tokens(l.strip) }
+                boundary = 0
             end
         end
 
-        @chunks << chunk
+        @chunks << lines.join unless lines.empty?
         @loaded = true
 
         self
+    end
+
+    def count_tokens(str)
+        return 0 if str.nil? || str.empty?
+        if str.match?(/\s/)
+            str.split(/\s+/).length
+        else
+            str.length
+        end
     end
 
     def get_chunk(idx)


### PR DESCRIPTION
## Summary
- split long text chunks in `TextReader` to stay under model limits
- ignore front matter delimiter `---` and handle blank line splitting when near token limits
- make indexing resilient to file-specific errors

## Testing
- `ruby -c readers/text.rb`
- `ruby -c exe/run-index`
- `bundle exec rake` *(fails: rake not included in Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_684528e779d88326907ad7311facab29