### PR TITLE
Improve indexing speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RAG on Markdown Files
 ## Setup
 
 - Setup Config JSON
-- Run `run-index config.json`
+- Run `run-index config.json` (processes each path concurrently)
 - Run `run-server config.json` and open `http://localhost:4567/q.html`
 
 ## Publishing

--- a/exe/run-index
+++ b/exe/run-index
@@ -29,7 +29,7 @@ if OPENAI_KEY.empty?
     exit 9
 end
 
-CONFIG.paths.each do |path|
+def index_path(path)
     STDOUT << "Read path name: #{path.name}, reader: #{path.reader}\n"
 
     # Read existing index
@@ -97,3 +97,9 @@ CONFIG.paths.each do |path|
 
     STDOUT << "]\nDone @#{Time.now}, Created: #{created}, Skipped: #{skipped}\n"
 end
+
+threads = CONFIG.paths.map do |path|
+    Thread.new { index_path(path) }
+end
+
+threads.each(&:join)


### PR DESCRIPTION
## Summary
- add concurrent processing of each configured path in `run-index`
- note multi-threading in README

## Testing
- `ruby -c exe/run-index`
- `bundle exec ruby -c exe/run-index`


------
https://chatgpt.com/codex/tasks/task_e_6845416a382483268fad2cd55603dbe1