### PR TITLE
Add duplicate finder to main server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ RAG on Markdown Files
 - Setup Config JSON
 - Run `run-index config.json` (processes each path concurrently)
 - Run `run-server config.json` and open `http://localhost:4567/q.html`
+- Open `http://localhost:4567/duplicate.html` to review duplicate clusters
 
 ## Publishing
 

--- a/exe/public/duplicate.html
+++ b/exe/public/duplicate.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Duplicate Finder</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            font-family: Arial, sans-serif;
+        }
+        #paths-list {
+            list-style-type: none;
+            padding: 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        #paths-list li {
+            display: flex;
+            align-items: center;
+        }
+        #paths-list label {
+            margin-left: 5px;
+        }
+        #threshold {
+            width: 60px;
+        }
+        .cluster {
+            border: 1px solid #ccc;
+            padding: 10px;
+            margin-bottom: 20px;
+        }
+        .card {
+            border: 1px solid #ddd;
+            padding: 10px;
+            margin: 5px;
+        }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+    <div>
+        <input type="number" id="threshold" value="0.9" step="0.05" min="0" max="1" />
+        <button id="find-btn">Find Duplicates</button>
+    </div>
+    <ul id="paths-list"></ul>
+    <div id="clusters"></div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const pathsList = document.getElementById('paths-list');
+            const findBtn = document.getElementById('find-btn');
+            const clustersDiv = document.getElementById('clusters');
+            const thresholdInput = document.getElementById('threshold');
+
+            fetch('http://localhost:4567/paths')
+                .then(resp => resp.json())
+                .then(data => {
+                    data.forEach(item => {
+                        const li = document.createElement('li');
+                        const checkbox = document.createElement('input');
+                        checkbox.type = 'checkbox';
+                        checkbox.id = item.name;
+                        checkbox.name = item.name;
+                        checkbox.checked = !!item.searchDefault;
+                        const label = document.createElement('label');
+                        label.htmlFor = item.name;
+                        label.textContent = item.name;
+                        li.appendChild(checkbox);
+                        li.appendChild(label);
+                        pathsList.appendChild(li);
+                    });
+                });
+
+            function renderClusters(clusters) {
+                clustersDiv.innerHTML = '';
+                clusters.forEach(cluster => {
+                    const div = document.createElement('div');
+                    div.className = 'cluster';
+                    const mergeBtn = document.createElement('button');
+                    mergeBtn.textContent = 'Merge All';
+                    mergeBtn.addEventListener('click', () => {
+                        alert('Merge placeholder');
+                    });
+                    div.appendChild(mergeBtn);
+                    cluster.forEach(item => {
+                        const card = document.createElement('div');
+                        card.className = 'card';
+                        card.innerHTML = `<div><strong>${item.path}:</strong> <a href="${item.url}">${item.id}</a></div>` +
+                                         `<div class="markdown">${marked.parse(item.text)}</div>`;
+                        div.appendChild(card);
+                    });
+                    clustersDiv.appendChild(div);
+                });
+            }
+
+            findBtn.addEventListener('click', () => {
+                const checkedPaths = Array.from(pathsList.querySelectorAll('input[type="checkbox"]:checked')).map(c => c.name);
+                const threshold = parseFloat(thresholdInput.value) || 0.9;
+                fetch('http://localhost:4567/duplicates', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ paths: checkedPaths, threshold: threshold })
+                }).then(resp => resp.json())
+                  .then(data => { renderClusters(data.clusters); });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/exe/run-server
+++ b/exe/run-server
@@ -14,6 +14,7 @@ require 'sinatra/base'
 require_relative "../server/retriever"
 require_relative "../server/synthesizer"
 require_relative "../server/discuss"
+require_relative "../server/duplicate"
 
 if ARGV.length != 1
     STDOUT << "Invalid arguments received, need a config file\n"
@@ -172,6 +173,24 @@ class SimpleRagServer < Sinatra::Application
         discussion = discuss_note(data["note"])
 
         { discussion: discussion }.to_json
+    end
+
+    # find duplicate notes across selected paths
+    post '/duplicates' do
+        content_type :json
+
+        data = JSON.parse(request.body.read)
+
+        selected = data["paths"]
+        threshold = (data["threshold"] || 0.9).to_f
+        if !selected || selected.empty?
+            selected = CONFIG.paths.map(&:name)
+        end
+        lookup_paths = selected.map { |name| CONFIG.path_map[name] }
+
+        clusters = find_duplicates(lookup_paths, threshold)
+
+        { clusters: clusters }.to_json
     end
 end
 

--- a/server/duplicate.rb
+++ b/server/duplicate.rb
@@ -1,0 +1,70 @@
+require "json"
+require_relative "../llm/embedding"
+require_relative "../readers/reader"
+require_relative "retriever" # for extract_id and extract_url
+
+# Find duplicate chunks across lookup paths using embedding similarity
+# Returns array of clusters, each an array of items with :path, :id, :url, :text
+
+def find_duplicates(lookup_paths, threshold = 0.9)
+  items = []
+
+  lookup_paths.each do |p|
+    index_file = File.expand_path(p.out)
+    next unless File.exist?(index_file)
+
+    reader_cls = get_reader(p.reader)
+    next unless reader_cls
+    file_cache = {}
+
+    File.foreach(index_file) do |line|
+      item = JSON.parse(line)
+      reader = file_cache[item["path"]] ||= reader_cls.new(item["path"]).load
+      text = reader.get_chunk(item["chunk"])
+      items << {
+        path: p.name,
+        id: extract_id(item["path"]),
+        url: extract_url(item["path"], p.url),
+        embedding: item["embedding"],
+        text: text
+      }
+    end
+  end
+
+  clusters = []
+  visited = Array.new(items.length, false)
+
+  items.each_with_index do |item, idx|
+    next if visited[idx]
+    cluster_indices = []
+    queue = [idx]
+    visited[idx] = true
+
+    until queue.empty?
+      i = queue.pop
+      cluster_indices << i
+      (i + 1...items.length).each do |j|
+        next if visited[j]
+        sim = cosine_similarity(items[i][:embedding], items[j][:embedding])
+        if sim >= threshold
+          visited[j] = true
+          queue << j
+        end
+      end
+    end
+
+    if cluster_indices.length > 1
+      clusters << cluster_indices.map do |cidx|
+        it = items[cidx]
+        {
+          path: it[:path],
+          id: it[:id],
+          url: it[:url],
+          text: it[:text]
+        }
+      end
+    end
+  end
+
+  clusters
+end


### PR DESCRIPTION
## Summary
- serve duplicate review page via `run-server`
- remove standalone `run-duplicate` command
- point `duplicate.html` to port 4567

## Testing
- `ruby -c server/duplicate.rb`
- `ruby -c exe/run-server`
- `ruby -c exe/run-index`
- `ruby -c exe/run-server`
- `ruby -c exe/run-setup`


------
https://chatgpt.com/codex/tasks/task_e_6847190392f48326bf8202af2e9f9e2b