### PR TITLE
Implement cached neighbor search

### DIFF
--- a/storage/index_cache.rb
+++ b/storage/index_cache.rb
@@ -1,0 +1,34 @@
+class PathIndex
+  attr_reader :items, :buckets, :reader_cls
+
+  def initialize(path_config)
+    @path_config = path_config
+    @items = []
+    @buckets = Hash.new { |h, k| h[k] = [] }
+    load!
+  end
+
+  def load!
+    index_file = File.expand_path(@path_config.out)
+    return unless File.exist?(index_file)
+
+    @reader_cls = get_reader(@path_config.reader)
+    return unless @reader_cls
+
+    File.foreach(index_file) do |line|
+      item = JSON.parse(line)
+      emb = normalize_embedding(item["embedding"])
+      idx = @items.length
+      bkey = bucket_key(emb)
+      @items << { embedding: emb, path: item["path"], chunk: item["chunk"], bucket: bkey }
+      @buckets[bkey] << idx
+    end
+  end
+end
+
+INDEX_CACHE = {}
+
+# Load and return PathIndex for a config path
+def load_index_cache(path_config)
+  INDEX_CACHE[path_config.name] ||= PathIndex.new(path_config)
+end


### PR DESCRIPTION
## Summary
- add `PathIndex` to load and bucket embeddings on startup
- speed up `retrieve_by_embedding` by using cached buckets
- speed up `find_duplicates` using the same in-memory index
- move `index_cache.rb` to `storage/`

## Testing
- `ruby -c server/retriever.rb`
- `ruby -c server/duplicate.rb`
- `ruby -c storage/index_cache.rb`
- `ruby -c exe/run-server`


------
https://chatgpt.com/codex/tasks/task_e_684c2fc32dbc83269ef98b9d2183eaa0