### PR TITLE
Implement random exploration for notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ RAG on Markdown Files
 - Run `run-index config.json` (processes each path concurrently)
 - Run `run-server config.json` and open `http://localhost:4567/q.html`
 - Open `http://localhost:4567/duplicate.html` to review duplicate clusters
+- Open `http://localhost:4567/random.html` to explore notes randomly
 
 ## Publishing
 

--- a/exe/public/random.html
+++ b/exe/public/random.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Random Notes</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            font-family: Arial, sans-serif;
+        }
+        #paths-list {
+            list-style-type: none;
+            padding: 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        #paths-list li {
+            display: flex;
+            align-items: center;
+        }
+        #paths-list label {
+            margin-left: 5px;
+        }
+        #random-button {
+            height: 40px;
+            margin-bottom: 20px;
+        }
+        #response-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        .card {
+            border: 1px solid #ccc;
+            padding: 10px;
+            border-radius: 5px;
+            width: calc(50% - 5px);
+            box-sizing: border-box;
+            cursor: pointer;
+        }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+    <button id="random-button">Random</button>
+    <ul id="paths-list"></ul>
+    <div id="response-container"></div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const pathsList = document.getElementById('paths-list');
+            const randomButton = document.getElementById('random-button');
+            const responseContainer = document.getElementById('response-container');
+
+            fetch('http://localhost:4567/paths')
+                .then(resp => resp.json())
+                .then(data => {
+                    data.forEach(item => {
+                        const li = document.createElement('li');
+                        const checkbox = document.createElement('input');
+                        checkbox.type = 'checkbox';
+                        checkbox.id = item.name;
+                        checkbox.name = item.name;
+                        checkbox.checked = !!item.searchDefault;
+                        const label = document.createElement('label');
+                        label.htmlFor = item.name;
+                        label.textContent = item.name;
+                        li.appendChild(checkbox);
+                        li.appendChild(label);
+                        pathsList.appendChild(li);
+                    });
+                });
+
+            function selectedPaths() {
+                return Array.from(pathsList.querySelectorAll('input[type="checkbox"]:checked')).map(c => c.name);
+            }
+
+            function renderCards(data) {
+                responseContainer.innerHTML = '';
+                data.data.forEach(item => {
+                    const div = document.createElement('div');
+                    div.className = 'card';
+                    div.dataset.note = item.text;
+                    div.innerHTML = `
+                        <div><strong>Path:</strong> <a href="${item.url}">${item.id}</a></div>
+                        <div class="markdown">${marked.parse(item.text)}</div>
+                    `;
+                    div.addEventListener('click', () => fetchSimilar(div.dataset.note));
+                    responseContainer.appendChild(div);
+                });
+            }
+
+            function fetchRandom() {
+                fetch('http://localhost:4567/random', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ paths: selectedPaths(), count: 3 })
+                }).then(resp => resp.json())
+                  .then(renderCards);
+            }
+
+            function fetchSimilar(note) {
+                fetch('http://localhost:4567/similar', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ paths: selectedPaths(), note: note, topN: 3 })
+                }).then(resp => resp.json())
+                  .then(renderCards);
+            }
+
+            randomButton.addEventListener('click', fetchRandom);
+        });
+    </script>
+</body>
+</html>

--- a/exe/run-server
+++ b/exe/run-server
@@ -192,6 +192,74 @@ class SimpleRagServer < Sinatra::Application
 
         { clusters: clusters }.to_json
     end
+
+    # return random notes from selected paths
+    post '/random' do
+        content_type :json
+
+        data = JSON.parse(request.body.read)
+
+        selected = data["paths"]
+        count = (data["count"] || 3).to_i
+        if !selected || selected.empty?
+            selected = CONFIG.paths.map(&:name)
+        end
+        lookup_paths = selected.map { |name| CONFIG.path_map[name] }
+
+        samples = []
+        lookup_paths.each do |p|
+            index = load_index_cache(p)
+            next unless index
+            reader_cls = index.reader_cls
+            next unless reader_cls
+
+            index.items.sample(count).each do |it|
+                samples << {
+                    path: p.name,
+                    lookup: p.name,
+                    id: extract_id(it[:path]),
+                    url: extract_url(it[:path], p.url),
+                    text: reader_cls.new(it[:path]).load.get_chunk(it[:chunk]),
+                    score: 0,
+                }
+            end
+        end
+
+        samples = samples.sample(count)
+
+        { data: samples }.to_json
+    end
+
+    # retrieve notes similar to provided note text
+    post '/similar' do
+        content_type :json
+
+        data = JSON.parse(request.body.read)
+
+        selected = data["paths"]
+        topN = (data["topN"] || 3).to_i
+        if !selected || selected.empty?
+            selected = CONFIG.paths.map(&:name)
+        end
+        lookup_paths = selected.map { |name| CONFIG.path_map[name] }
+
+        entries = retrieve_by_embedding(lookup_paths, data["note"] || "")
+        entries = entries.sort_by { |item| -item["score"] }.take(topN)
+
+        resp = { data: [] }
+        entries.each do |item|
+            resp[:data] << {
+                path: item["path"],
+                lookup: item["lookup"],
+                id: item["id"],
+                url: item["url"],
+                text: item["reader"].load.get_chunk(item["chunk"]),
+                score: item["score"],
+            }
+        end
+
+        resp.to_json
+    end
 end
 
 SimpleRagServer.run!


### PR DESCRIPTION
## Summary
- add `/random` and `/similar` endpoints to the server
- provide a new `random.html` page for exploring random notes and getting similar ones
- document new random page in README

## Testing
- `ruby -c exe/run-server`

------
https://chatgpt.com/codex/tasks/task_e_684c3a9ab1348326969880dad639e482