### PR TITLE
Switch to treemap visualization

### DIFF
--- a/exe/public/graph.html
+++ b/exe/public/graph.html
@@ -54,22 +54,13 @@
         }
         .node {
             position: absolute;
-            width: 200px;
-            height: 120px;
-            overflow-y: auto;
+            overflow: auto;
             border: 1px solid #ccc;
             padding: 5px;
             border-radius: 5px;
             background: #fff;
             box-sizing: border-box;
             font-size: 12px;
-        }
-        #lines-canvas {
-            position: absolute;
-            left: 0;
-            top: 0;
-            pointer-events: none;
-            transform-origin: 0 0;
         }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -84,7 +75,6 @@
         <ul id="paths-list"></ul>
     </div>
     <div id="graph-wrapper">
-        <svg id="lines-canvas"></svg>
         <div id="graph"></div>
     </div>
 
@@ -96,7 +86,6 @@
         const searchPlusButton = document.getElementById('search-plus-button');
         const graphWrapper = document.getElementById('graph-wrapper');
         const graph = document.getElementById('graph');
-        const svg = document.getElementById('lines-canvas');
 
         let offsetX = 0, offsetY = 0;
         let scale = 1;
@@ -105,16 +94,9 @@
 
         function setTransform() {
             graph.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
-            svg.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
-        }
-
-        function resizeCanvas() {
-            svg.setAttribute('width', graphWrapper.clientWidth);
-            svg.setAttribute('height', graphWrapper.clientHeight);
         }
 
         window.addEventListener('resize', function() {
-            resizeCanvas();
             scale = 1;
             offsetX = graphWrapper.clientWidth / 2;
             offsetY = graphWrapper.clientHeight / 2;
@@ -178,99 +160,25 @@
             return Array.from(pathsList.querySelectorAll('input[type="checkbox"]:checked')).map(c => c.name);
         }
 
-        let currentItems = [];
-        let itemSet = new Set();
-        let nodes = [];
-        let links = [];
-        let simulation = null;
+        let rootNode = null;
+        const nodeMap = new Map();
+        const MIN_VALUE = 0.1;
 
-        function addNode(item, isQuery=false) {
-            const n = {
-                id: isQuery ? 'query' : item.url,
-                item: item
-            };
-            const div = document.createElement('div');
-            div.className = 'node';
-            if (isQuery) {
-                div.innerHTML = `<strong>${item}</strong>`;
-            } else {
-                applyBackgroundColor(div, item.lookup);
-                div.dataset.note = item.text;
-                div.innerHTML = `\n                    <div><strong>Path:</strong> <a href="${item.url}">${item.id}</a></div>\n                    <div><strong>Score:</strong> ${item.score}</div>\n                    <div class="markdown-content">${marked.parse(item.text)}</div>\n                `;
-                div.addEventListener('dblclick', () => fetchSimilar(n));
-            }
-            graph.appendChild(div);
-            n.div = div;
-            nodes.push(n);
-            return n;
+        function addChild(parent, item) {
+            if (nodeMap.has(item.url)) return;
+            const child = { id: item.url, item: item, children: [] };
+            parent.children.push(child);
+            nodeMap.set(child.id, child);
         }
 
-        function startSimulation() {
-            if (simulation) simulation.stop();
-            simulation = d3.forceSimulation(nodes)
-                .force('link', d3.forceLink(links)
-                    .id(d => d.id)
-                    .distance(d => Math.max(50, 200 * (1 - (d.score || 0))))
-                    .strength(d => Math.max(0.1, d.score || 0)))
-                .force('charge', d3.forceManyBody().strength(-300))
-                .force('center', d3.forceCenter(0, 0));
-
-            simulation.on('tick', () => {
-                d3.select(svg).selectAll('line')
-                    .data(links)
-                    .join('line')
-                    .attr('stroke', '#999')
-                    .attr('x1', d => d.source.x)
-                    .attr('y1', d => d.source.y)
-                    .attr('x2', d => d.target.x)
-                    .attr('y2', d => d.target.y);
-
-                nodes.forEach(n => {
-                    if (!n.div) return;
-                    n.div.style.left = `${n.x - 100}px`;
-                    n.div.style.top = `${n.y - 60}px`;
-                });
-            });
-        }
-
-        function renderGraph(items) {
-            currentItems = items.slice();
-            itemSet = new Set(items.map(it => it.url));
-            nodes = [];
-            links = [];
+        function buildTree(items) {
             graph.innerHTML = '';
-            svg.innerHTML = '';
-
-            resizeCanvas();
-            offsetX = graphWrapper.clientWidth / 2;
-            offsetY = graphWrapper.clientHeight / 2;
-            setTransform();
-
-            const qNode = addNode(searchInput.value, true);
-            items.forEach(it => {
-                const n = addNode(it);
-                links.push({ source: qNode, target: n, score: it.score });
-            });
-
-            startSimulation();
-        }
-
-        function addItems(newItems, parentNode) {
-            let changed = false;
-            newItems.forEach(it => {
-                let target = nodes.find(n => n.id === it.url);
-                if (!target) {
-                    target = addNode(it);
-                    itemSet.add(it.url);
-                    currentItems.push(it);
-                    changed = true;
-                }
-                if (parentNode) {
-                    links.push({ source: parentNode, target: target, score: it.score });
-                    changed = true;
-                }
-            });
-            if (changed) startSimulation();
+            if (!items || items.length === 0) { rootNode = null; return; }
+            nodeMap.clear();
+            rootNode = { id: items[0].url, item: items[0], children: [] };
+            nodeMap.set(rootNode.id, rootNode);
+            items.slice(1).forEach(it => addChild(rootNode, it));
+            renderTreemap();
         }
 
         function fetchSimilar(node) {
@@ -280,8 +188,58 @@
                 body: JSON.stringify({ paths: selectedPaths(), note: node.item.text, topN: 3 })
             }).then(resp => resp.json())
               .then(resp => {
-                  addItems(resp.data, node);
+                  resp.data.forEach(it => addChild(node, it));
+                  renderTreemap();
               });
+        }
+
+        function renderTreemap() {
+            if (!rootNode) return;
+            graph.innerHTML = '';
+            const width = graphWrapper.clientWidth;
+            const height = graphWrapper.clientHeight;
+
+            const root = d3.hierarchy(rootNode)
+                .sum(d => Math.max(d.item ? d.item.score : 0, MIN_VALUE))
+                .sort((a, b) => b.value - a.value);
+
+            d3.treemap()
+                .size([width, height])
+                .padding(2)
+                .tile(d3.treemapSquarify)(root);
+
+            const sel = d3.select(graph)
+                .selectAll('div.node')
+                .data(root.descendants(), d => d.data.id);
+
+            sel.exit().remove();
+
+            const enter = sel.enter().append('div')
+                .attr('class', 'node')
+                .on('dblclick', (event, d) => {
+                    if (d.depth === 0) return;
+                    fetchSimilar(d.data);
+                });
+            enter.append('div').attr('class', 'content');
+
+            const merged = enter.merge(sel);
+            merged.each(function(d) {
+                if (d.data.item) applyBackgroundColor(this, d.data.item.lookup);
+            });
+
+            merged.select('.content').html(d => {
+                if (!d.data.item) return `<strong>ROOT</strong>`;
+                return `
+                    <div><strong>Path:</strong> <a href="${d.data.item.url}">${d.data.item.id}</a></div>
+                    <div><strong>Score:</strong> ${d.data.item.score}</div>
+                    <div class="markdown-content">${marked.parse(d.data.item.text)}</div>
+                `;
+            });
+
+            merged.style('left', d => `${d.x0}px`)
+                .style('top', d => `${d.y0}px`)
+                .style('width', d => `${Math.max(20, d.x1 - d.x0)}px`)
+                .style('height', d => `${Math.max(20, d.y1 - d.y0)}px`);
         }
 
         function performSearch(url) {
@@ -291,7 +249,7 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ q: query, paths: selectedPaths() })
             }).then(resp => resp.json())
-              .then(resp => { renderGraph(resp.data); });
+              .then(resp => { buildTree(resp.data); });
         }
 
         searchButton.addEventListener('click', () => performSearch('http://localhost:4567/q'));


### PR DESCRIPTION
## Summary
- replace force-directed layout with a cascaded treemap in `graph.html`
- size rectangles by similarity score and allow double-click expansion

## Testing
- `bundle exec rake test` *(fails: rake not in bundle)*

------
https://chatgpt.com/codex/tasks/task_e_6859769df7bc8326b4e589b78a49f343