### PR TITLE
Fix root display in graph search

### DIFF
--- a/exe/public/graph.html
+++ b/exe/public/graph.html
@@ -175,9 +175,9 @@
             graph.innerHTML = '';
             if (!items || items.length === 0) { rootNode = null; return; }
             nodeMap.clear();
-            rootNode = { id: items[0].url, item: items[0], children: [] };
+            rootNode = { id: 'root', item: null, children: [] };
             nodeMap.set(rootNode.id, rootNode);
-            items.slice(1).forEach(it => addChild(rootNode, it));
+            items.forEach(it => addChild(rootNode, it));
             renderTreemap();
         }
 
@@ -224,8 +224,12 @@
 
             const merged = enter.merge(sel);
             merged.each(function(d) {
-                if (d.data.item) applyBackgroundColor(this, d.data.item.lookup);
+                if (d.data.item) {
+                    applyBackgroundColor(this, d.data.item.lookup);
+                }
             });
+
+            merged.style('display', d => d.data.item ? 'block' : 'none');
 
             merged.select('.content').html(d => {
                 if (!d.data.item) return `<strong>ROOT</strong>`;


### PR DESCRIPTION
## Summary
- ensure search results render under a blank root so first result is visible
- hide root node during rendering

## Testing
- `bundle exec rake` *(fails: can't find executable rake)*

------
https://chatgpt.com/codex/tasks/task_e_685aaa5b161c8326b78a249b1f8e89bf