### PR TITLE
Add grouped extraction retrieval and display

### DIFF
--- a/exe/public/reader.html
+++ b/exe/public/reader.html
@@ -131,6 +131,24 @@
                                    '<div class="markdown-content">' + marked.parse(data.extraction) + '</div>';
                 responseContainer.appendChild(extDiv);
 
+                if (data.retrievals && data.retrievals.length > 0) {
+                    const retDiv = document.createElement('div');
+                    retDiv.className = 'response-item';
+                    applyBackgroundColor(retDiv, 'retrieval');
+                    let html = '<h3>Retrievals</h3>';
+                    data.retrievals.forEach((grp, idx) => {
+                        html += `<div><strong>Group ${idx + 1}</strong></div>`;
+                        grp.forEach(item => {
+                            html += `
+                                <div><strong>Path:</strong> <a href="${item.url}">${item.id}</a> (${item.score.toFixed(3)})</div>
+                                <div class="markdown-content">${marked.parse(item.text)}</div>
+                            `;
+                        });
+                    });
+                    retDiv.innerHTML = html;
+                    responseContainer.appendChild(retDiv);
+                }
+
                 const argDiv = document.createElement('div');
                 argDiv.className = 'response-item';
                 applyBackgroundColor(argDiv, 'argument');

--- a/exe/run-server
+++ b/exe/run-server
@@ -307,28 +307,31 @@ class SimpleRagServer < Sinatra::Application
 
         article = fetch_article(url) rescue ''
         extraction = extract_article(article)
+        groups = split_extraction_groups(extraction)
 
-        entries = retrieve_by_embedding(lookup_paths, extraction)
-        entries = entries.sort_by { |item| -item['score'] }.take(5)
-
-        retrieved = []
+        retrievals = []
         notes = []
-        entries.each do |item|
-            text = item['reader'].load.get_chunk(item['chunk'])
-            retrieved << {
-                path: item['path'],
-                lookup: item['lookup'],
-                id: item['id'],
-                url: item['url'],
-                text: text,
-                score: item['score'],
-            }
-            notes << text
+        groups.each do |g|
+            entries = retrieve_by_embedding(lookup_paths, g)
+            entries = entries.sort_by { |item| -item['score'] }.take(5)
+
+            retrievals << entries.map do |item|
+                text = item['reader'].load.get_chunk(item['chunk'])
+                notes << text
+                {
+                    path: item['path'],
+                    lookup: item['lookup'],
+                    id: item['id'],
+                    url: item['url'],
+                    text: text,
+                    score: item['score'],
+                }
+            end
         end
 
         argument = argue_new_content(notes, extraction)
 
-        { extraction: extraction, argument: argument, data: retrieved }.to_json
+        { extraction: extraction, argument: argument, retrievals: retrievals }.to_json
     end
 end
 

--- a/server/article.rb
+++ b/server/article.rb
@@ -5,6 +5,7 @@ JINA_READER_API = 'https://r.jina.ai/'
 
 EXTRACT_PROMPT = <<~PROMPT
 Extract the core concepts, opinions and discussions from the following text.
+Organize related points into groups separated by blank lines.
 Return the result in concise markdown bullet points.
 PROMPT
 
@@ -40,6 +41,13 @@ def extract_article(text)
     { role: ROLE_USER, content: text }
   ]
   chat(msgs)
+end
+
+# Split the extracted text into thematic groups separated by blank lines.
+# extraction: string returned from +extract_article+
+# Returns an array of strings, one per group.
+def split_extraction_groups(extraction)
+  extraction.to_s.strip.split(/\n\s*\n+/).map(&:strip).reject(&:empty?)
 end
 
 # Compare article with existing notes to highlight new or opposing info


### PR DESCRIPTION
## Summary
- update article extraction to return groups separated by blank lines
- search each group during URL reading
- show grouped retrieval results in the reader UI

## Testing
- `ruby -c server/article.rb`
- `ruby -c exe/run-server`

------
https://chatgpt.com/codex/tasks/task_e_68623618097483269645056e5de65b2f