### PR TITLE
Add article caching

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -10,7 +10,8 @@
         "model": "text-embedding-3-small"
     },
     "jina": {
-        "token": ""
+        "token": "",
+        "cacheDir": ""
     },
     "dismissedDuplicatesFile": "dismissed.txt",
     "paths": [

--- a/exe/run-server
+++ b/exe/run-server
@@ -331,6 +331,8 @@ class SimpleRagServer < Sinatra::Application
 
         argument = argue_new_content(notes, extraction)
 
+        save_article_result(url, article, extraction, argument)
+
         { extraction: extraction, argument: argument, retrievals: retrievals }.to_json
     end
 end


### PR DESCRIPTION
## Summary
- expose cache directory for Jina in example config
- cache URL reader output in Markdown
- save new content from URL reader

## Testing
- `ruby -c exe/run-server`
- `ruby -c server/article.rb`


------
https://chatgpt.com/codex/tasks/task_e_686237ca04388326966bf4865db14d65