### PR TITLE
Add Gemini LLM support

### DIFF
--- a/exe/run-index
+++ b/exe/run-index
@@ -24,8 +24,18 @@ CONFIG = OpenStruct.new(config)
 CONFIG.paths = CONFIG.paths.map { |p| OpenStruct.new(p) }
 
 OPENAI_KEY = ENV["DOT_OPENAI_KEY"] || ""
-if OPENAI_KEY.empty?
+GEMINI_KEY = ENV["DOT_GEMINI_KEY"] || ""
+
+chat_provider = CONFIG.dig(:chat, :provider) || CONFIG.dig("chat", "provider") || 'openai'
+embedding_provider = CONFIG.dig(:embedding, :provider) || CONFIG.dig("embedding", "provider") || 'openai'
+
+if (chat_provider.downcase == 'openai' || embedding_provider.downcase == 'openai') && OPENAI_KEY.empty?
     STDOUT << "Remember to set env DOT_OPENAI_KEY\n"
+    exit 9
+end
+
+if (chat_provider.downcase == 'gemini' || embedding_provider.downcase == 'gemini') && GEMINI_KEY.empty?
+    STDOUT << "Remember to set env DOT_GEMINI_KEY\n"
     exit 9
 end
 

--- a/exe/run-server
+++ b/exe/run-server
@@ -45,8 +45,18 @@ end
 
 
 OPENAI_KEY = ENV["DOT_OPENAI_KEY"] || ""
-if OPENAI_KEY.empty?
+GEMINI_KEY = ENV["DOT_GEMINI_KEY"] || ""
+
+chat_provider = CONFIG.dig(:chat, :provider) || CONFIG.dig("chat", "provider") || 'openai'
+embedding_provider = CONFIG.dig(:embedding, :provider) || CONFIG.dig("embedding", "provider") || 'openai'
+
+if (chat_provider.downcase == 'openai' || embedding_provider.downcase == 'openai') && OPENAI_KEY.empty?
     STDOUT << "Remember to set env DOT_OPENAI_KEY\n"
+    exit 9
+end
+
+if (chat_provider.downcase == 'gemini' || embedding_provider.downcase == 'gemini') && GEMINI_KEY.empty?
+    STDOUT << "Remember to set env DOT_GEMINI_KEY\n"
     exit 9
 end
 

--- a/llm/gemini.rb
+++ b/llm/gemini.rb
@@ -1,0 +1,59 @@
+require_relative "http"
+
+# Send POST request to Gemini API with API key header
+
+def gemini_http_post(uri, key, data)
+  url = URI(uri)
+  http = Net::HTTP.new(url.host, url.port)
+  http.use_ssl = true
+  http.read_timeout = 600
+
+  headers = { "Content-Type" => "application/json", "x-goog-api-key" => key }
+  request = Net::HTTP::Post.new(url, headers)
+  request.body = data.to_json
+
+  http.request(request)
+end
+
+# Call Google Gemini chat API
+
+def gemini_chat(messages, model, base_url, opts = {})
+  api_url = base_url.end_with?('/') ? "#{base_url}#{model}:generateContent" : "#{base_url}/#{model}:generateContent"
+
+  contents = messages.map do |m|
+    {
+      "role" => m[:role] || m["role"],
+      "parts" => [{ "text" => m[:content] || m["content"] }]
+    }
+  end
+  data = { "contents" => contents }.merge(opts)
+
+  response = gemini_http_post(api_url, GEMINI_KEY, data)
+
+  if response.code != "200"
+    STDOUT << "Chat error: #{response}\n"
+    exit 1
+  end
+
+  result = JSON.parse(response.body)
+  result["candidates"][0]["content"]["parts"][0]["text"]
+end
+
+# Call Google Gemini embedding API
+
+def gemini_embedding(txts, model, base_url, opts = {})
+  api_url = base_url.end_with?('/') ? "#{base_url}#{model}:embedContent" : "#{base_url}/#{model}:embedContent"
+
+  content = { "parts" => [{ "text" => txts }] }
+  data = { "model" => "models/#{model}", "content" => content }.merge(opts)
+
+  response = gemini_http_post(api_url, GEMINI_KEY, data)
+
+  if response.code != "200"
+    STDOUT << "Embedding error: #{response.body}\n"
+    exit 1
+  end
+
+  result = JSON.parse(response.body)
+  result["embedding"]["values"]
+end

--- a/llm/llm.rb
+++ b/llm/llm.rb
@@ -1,5 +1,6 @@
 require_relative "openai"
 require_relative "ollama"
+require_relative "gemini"
 
 ROLE_SYSTEM = "system"
 ROLE_USER = "user"
@@ -33,6 +34,10 @@ def chat(messages, opts = {})
     model = cfg(:chat, 'model', 'llama2')
     url = cfg(:chat, 'url', 'http://localhost:11434/api/chat')
     ollama_chat(messages, model, url, opts)
+  when 'gemini'
+    model = cfg(:chat, 'model', 'gemini-2.5-flash')
+    url = cfg(:chat, 'url', 'https://generativelanguage.googleapis.com/v1beta/models')
+    gemini_chat(messages, model, url, opts)
   else
     model = cfg(:chat, 'model', 'gpt-4.1-mini')
     url = cfg(:chat, 'url', 'https://api.openai.com/v1/chat/completions')
@@ -49,6 +54,10 @@ def embedding(txts, opts = {})
     model = cfg(:embedding, 'model', 'nomic-embed-text')
     url = cfg(:embedding, 'url', 'http://localhost:11434/api/embeddings')
     ollama_embedding(txts, model, url, opts)
+  when 'gemini'
+    model = cfg(:embedding, 'model', 'gemini-embedding-001')
+    url = cfg(:embedding, 'url', 'https://generativelanguage.googleapis.com/v1beta/models')
+    gemini_embedding(txts, model, url, opts)
   else
     model = cfg(:embedding, 'model', 'text-embedding-3-small')
     url = cfg(:embedding, 'url', 'https://api.openai.com/v1/embeddings')


### PR DESCRIPTION
## Summary
- implement Gemini chat and embedding helpers
- route Gemini provider in LLM router
- allow Gemini API key in executables with provider checks
- build Gemini URLs in helper functions

## Testing
- `ruby -c llm/gemini.rb`
- `ruby -c llm/llm.rb`
- `ruby -c exe/run-server`
- `ruby -c exe/run-index`


------
https://chatgpt.com/codex/tasks/task_e_68768ce2f8a883268235ab0d19e32594