### PR TITLE
Add OpenRouter LLM provider support

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -1,12 +1,12 @@
 {
     "chat": {
-        "provider": "openai",
-        "url": "",
-        "model": "gpt-3.5-turbo-16k"
+        "provider": "openrouter",
+        "url": "https://openrouter.ai/api/v1/chat/completions",
+        "model": "gpt-3.5-turbo"
     },
     "embedding": {
-        "provider": "openai",
-        "url": "",
+        "provider": "openrouter",
+        "url": "https://openrouter.ai/api/v1/embeddings",
         "model": "text-embedding-3-small"
     },
     "jina": {

--- a/exe/run-index
+++ b/exe/run-index
@@ -25,6 +25,7 @@ CONFIG.paths = CONFIG.paths.map { |p| OpenStruct.new(p) }
 
 OPENAI_KEY = ENV["DOT_OPENAI_KEY"] || ""
 GEMINI_KEY = ENV["DOT_GEMINI_KEY"] || ""
+OPENROUTER_KEY = ENV["DOT_OPENROUTER_KEY"] || ""
 
 chat_provider = CONFIG.dig(:chat, :provider) || CONFIG.dig("chat", "provider") || 'openai'
 embedding_provider = CONFIG.dig(:embedding, :provider) || CONFIG.dig("embedding", "provider") || 'openai'
@@ -36,6 +37,11 @@ end
 
 if (chat_provider.downcase == 'gemini' || embedding_provider.downcase == 'gemini') && GEMINI_KEY.empty?
     STDOUT << "Remember to set env DOT_GEMINI_KEY\n"
+    exit 9
+end
+
+if (chat_provider.downcase == 'openrouter' || embedding_provider.downcase == 'openrouter') && OPENROUTER_KEY.empty?
+    STDOUT << "Remember to set env DOT_OPENROUTER_KEY\n"
     exit 9
 end
 

--- a/exe/run-server
+++ b/exe/run-server
@@ -46,6 +46,7 @@ end
 
 OPENAI_KEY = ENV["DOT_OPENAI_KEY"] || ""
 GEMINI_KEY = ENV["DOT_GEMINI_KEY"] || ""
+OPENROUTER_KEY = ENV["DOT_OPENROUTER_KEY"] || ""
 
 chat_provider = CONFIG.dig(:chat, :provider) || CONFIG.dig("chat", "provider") || 'openai'
 embedding_provider = CONFIG.dig(:embedding, :provider) || CONFIG.dig("embedding", "provider") || 'openai'
@@ -57,6 +58,11 @@ end
 
 if (chat_provider.downcase == 'gemini' || embedding_provider.downcase == 'gemini') && GEMINI_KEY.empty?
     STDOUT << "Remember to set env DOT_GEMINI_KEY\n"
+    exit 9
+end
+
+if (chat_provider.downcase == 'openrouter' || embedding_provider.downcase == 'openrouter') && OPENROUTER_KEY.empty?
+    STDOUT << "Remember to set env DOT_OPENROUTER_KEY\n"
     exit 9
 end
 

--- a/llm/llm.rb
+++ b/llm/llm.rb
@@ -1,6 +1,7 @@
 require_relative "openai"
 require_relative "ollama"
 require_relative "gemini"
+require_relative "openrouter"
 
 ROLE_SYSTEM = "system"
 ROLE_USER = "user"
@@ -38,6 +39,10 @@ def chat(messages, opts = {})
     model = cfg(:chat, 'model', 'gemini-2.5-flash')
     url = cfg(:chat, 'url', 'https://generativelanguage.googleapis.com/v1beta/models')
     gemini_chat(messages, model, url, opts)
+  when 'openrouter'
+    model = cfg(:chat, 'model', 'gpt-4.1-mini')
+    url = cfg(:chat, 'url', 'https://openrouter.ai/api/v1/chat/completions')
+    openrouter_chat(messages, model, url, opts)
   else
     model = cfg(:chat, 'model', 'gpt-4.1-mini')
     url = cfg(:chat, 'url', 'https://api.openai.com/v1/chat/completions')
@@ -58,6 +63,10 @@ def embedding(txts, opts = {})
     model = cfg(:embedding, 'model', 'gemini-embedding-001')
     url = cfg(:embedding, 'url', 'https://generativelanguage.googleapis.com/v1beta/models')
     gemini_embedding(txts, model, url, opts)
+  when 'openrouter'
+    model = cfg(:embedding, 'model', 'text-embedding-3-small')
+    url = cfg(:embedding, 'url', 'https://openrouter.ai/api/v1/embeddings')
+    openrouter_embedding(txts, model, url, opts)
   else
     model = cfg(:embedding, 'model', 'text-embedding-3-small')
     url = cfg(:embedding, 'url', 'https://api.openai.com/v1/embeddings')

--- a/llm/openrouter.rb
+++ b/llm/openrouter.rb
@@ -1,0 +1,41 @@
+require_relative "http"
+
+# Chat with OpenRouter
+
+def openrouter_chat(messages, model, url, opts = {})
+  data = {
+    "model" => model,
+    "messages" => messages
+  }.merge(opts)
+
+  response = http_post(url, OPENROUTER_KEY, data)
+
+  if response.code != "200"
+    STDOUT << "Chat error: #{response}\n"
+    exit 1
+  end
+
+  result = JSON.parse(response.body)
+  STDOUT << "Chat usage: #{result["usage"]}, model: #{data["model"]}\n"
+
+  result["choices"][0]["message"]["content"]
+end
+
+# Create embeddings with OpenRouter
+
+def openrouter_embedding(txts, model, url, opts = {})
+  data = {
+    "model" => model,
+    "input" => txts
+  }.merge(opts)
+
+  response = http_post(url, OPENROUTER_KEY, data)
+
+  if response.code != "200"
+    STDOUT << "Embedding error: #{response.body}\n"
+    exit 1
+  end
+
+  result = JSON.parse(response.body)
+  result["data"][0]["embedding"]
+end


### PR DESCRIPTION
## Summary
- support OpenRouter chat and embedding APIs
- require DOT_OPENROUTER_KEY for OpenRouter usage
- document OpenRouter configuration in example_config

## Testing
- `bundle exec ruby -c llm/openrouter.rb`
- `bundle exec ruby -c llm/llm.rb`
- `bundle exec ruby -c exe/run-server`
- `bundle exec ruby -c exe/run-index`
- `jq . example_config.json`

------
https://chatgpt.com/codex/tasks/task_e_68beffcdc7788326a65e602619e50595